### PR TITLE
Fix: Prevent onBlockUse from being called twice in Forge 1.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.parallel=true
 
-mod_version=3.2.3+1.20.1-forge
-release_name=V3.2.3 [1.20.1 Forge]
+mod_version=3.2.4+1.20.1-forge
+release_name=V3.2.4 [1.20.1 Forge]
 archive_base_name=right-click-harvest
 supported_versions=1.20.1
 

--- a/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvestModInit.java
+++ b/src/main/java/io/github/jamalam360/rightclickharvest/RightClickHarvestModInit.java
@@ -95,7 +95,7 @@ public class RightClickHarvestModInit {
 	}
 
 	public void onCommonSetup(final FMLCommonSetupEvent event) {
-		MinecraftForge.EVENT_BUS.<PlayerInteractEvent.RightClickBlock>addListener(this::onBlockUse);
+		// MinecraftForge.EVENT_BUS.<PlayerInteractEvent.RightClickBlock>addListener(this::onBlockUse);
 		LOGGER.info("Initialized");
 	}
 


### PR DESCRIPTION
I think it should not register the subscriber(in `commonSetup` and `register(this)` ) multiple times?